### PR TITLE
Add Max Stats addon for Minecraft Bedrock

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,1 +1,9 @@
-This is test repository.
+# Max Stats Add-on
+
+This repository contains a small Minecraft Bedrock add-on that grants all players maximum attack and defense. The behavior pack applies Strength and Resistance effects with high duration and amplifier each tick.
+
+## Installation
+1. Copy the `max_stats_bp` folder into your world's `behavior_packs` directory.
+2. Enable the pack from the world settings and start the game.
+
+All players will automatically receive the effects when they join.

--- a/max_stats_bp/functions/apply_max.mcfunction
+++ b/max_stats_bp/functions/apply_max.mcfunction
@@ -1,0 +1,2 @@
+effect @a strength 1000000 255 true
+effect @a resistance 1000000 255 true

--- a/max_stats_bp/functions/tick.json
+++ b/max_stats_bp/functions/tick.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apply_max"
+  ]
+}

--- a/max_stats_bp/manifest.json
+++ b/max_stats_bp/manifest.json
@@ -1,0 +1,18 @@
+{
+  "format_version": 2,
+  "header": {
+    "description": "Gives players maximum attack and defense by applying strength and resistance effects.",
+    "name": "Max Stats",
+    "uuid": "8a639f07-678f-4356-9dde-bf84476879ed",
+    "version": [1, 0, 0],
+    "min_engine_version": [1, 19, 0]
+  },
+  "modules": [
+    {
+      "description": "Max Stats behavior module",
+      "type": "data",
+      "uuid": "d9418899-42b7-466e-b048-5cfd1e11a1ec",
+      "version": [1, 0, 0]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create a `max_stats_bp` behavior pack that grants Strength and Resistance every tick
- document the addon in `ReadMe.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850f625a79c832eac3fb1dfa3a93206